### PR TITLE
Fix escape sequence handling in send_keys

### DIFF
--- a/server.py
+++ b/server.py
@@ -9,6 +9,7 @@ Supports two modes:
 """
 
 import asyncio
+import codecs
 import pexpect
 import pyte
 import re
@@ -204,7 +205,9 @@ def send_keys(
             return f"✗ No active session found: {session_id}"
 
         session = sessions[session_id]
-        session.send(keys)
+        # Decode Python escape sequences (\x1b, \n, \t, etc.)
+        decoded_keys = codecs.decode(keys, 'unicode_escape')
+        session.send(decoded_keys)
 
         # Additional delay if requested
         if delay > 0.1:


### PR DESCRIPTION
## Problem
When using the MCP tool, escape sequences like `\x1b` (ESC key) are passed as literal strings through JSON, not as actual control characters. This makes it impossible to send special keys like ESC to TUI applications.

## Solution
Added `codecs.decode(keys, 'unicode_escape')` to properly interpret Python escape sequences before sending to pexpect.

## Testing
Tested with a bubbletea-based TUI application:
- `\x1b` now correctly sends ESC key
- `\r` correctly sends Enter (CR)
- `\t` correctly sends Tab

---

Thank you for creating this amazing tool! This fix has made TUI development and testing so much easier. 🙏